### PR TITLE
Add nvim-tree.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,3 @@
 -- vim.go.loadplugins = false
 -- Call setup
-pcall(require, "core")
+require("core")

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,6 +1,7 @@
 {
   "Comment.nvim": { "branch": "master", "commit": "6821b3ae27a57f1f3cf8ed030e4a55d70d0c4e43" },
   "LuaSnip": { "branch": "master", "commit": "58236e8b2f20de23ff35106dace9212b41d78860" },
+  "chadtree": { "branch": "chad", "commit": "1188c4a39167237d551d279c9f84a3e34c7c2329" },
   "cmp-buffer": { "branch": "main", "commit": "3022dbc9166796b644a841a02de8dd1cc1d311fa" },
   "cmp-nvim-lsp": { "branch": "main", "commit": "0e6b2ed705ddcff9738ec4ea838141654f12eeef" },
   "cmp_luasnip": { "branch": "master", "commit": "18095520391186d634a0045dacaa346291096566" },
@@ -21,6 +22,7 @@
   "nvim-cmp": { "branch": "main", "commit": "01f697a68905f9dcae70960a9eb013695a17f9a2" },
   "nvim-colorizer.lua": { "branch": "master", "commit": "dde3084106a70b9a79d48f426f6d6fec6fd203f7" },
   "nvim-lspconfig": { "branch": "master", "commit": "e0926b6abc84578f44fb8917d61cdee22188639e" },
+  "nvim-tree.lua": { "branch": "master", "commit": "bbb6d4891009de7dab05ad8fc2d39f272d7a751c" },
   "nvim-treesitter": { "branch": "master", "commit": "1ceaceb9dea9b0bac2162345ee11e47a44e07a70" },
   "nvim-ufo": { "branch": "main", "commit": "9e829d5cfa3de6a2ff561d86399772b0339ae49d" },
   "nvim-web-devicons": { "branch": "master", "commit": "c3c1dc4e36969370ff589b7025df8ec2e5c881a2" },

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -13,6 +13,7 @@ vim.defer_fn(function()
   require("core.autocmd")
   require("mappings.movement")
   require("mappings.lspsaga")
+  require("mappings.plugins")
 
   o("shadafile", "", {})
 end, 0)

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -19,8 +19,11 @@ o("clipboard", "unnamed,unnamedplus", {}) -- Let's sync clipboards across platfo
 o("showtabline", 2, {})
 vim.api.nvim_command([[au FileType * if index(['wipe', 'delete'], &bufhidden) >= 0 | set nobuflisted | endif]])
 
--- For vim-matchup
+-- 1.5 Vim-matchup
 vim.g.matchup_matchparen_offscreen = { method = "popup" }
+
+-- Set the shell to bash.
+-- o("shell", "/bin/bash", {}) -- Fish is a bit buggy on Neovim.
 
 -- =======================================
 -- 2. Editing options.

--- a/lua/mappings/plugins.lua
+++ b/lua/mappings/plugins.lua
@@ -1,0 +1,4 @@
+local maps = vim.api.nvim_set_keymap
+
+-- Open NvimTree via `<leader>tr`
+maps("n", "<leader>tr", "<cmd>:NvimTreeToggle<CR>", { desc = "Open Nvim tree." })

--- a/lua/plugins/configs/tools/tree.lua
+++ b/lua/plugins/configs/tools/tree.lua
@@ -1,0 +1,19 @@
+require("nvim-tree").setup({
+  renderer = {
+    full_name = true,
+    group_empty = true,
+    symlink_destination = false,
+    indent_markers = {
+      enable = true,
+    },
+  },
+  icons = {
+    git_placement = "signcolumn",
+    show = {
+      file = true,
+      folder = true,
+      folder_arrow = true,
+      git = true
+    }
+  }
+})

--- a/lua/plugins/configs/tools/tree.lua
+++ b/lua/plugins/configs/tools/tree.lua
@@ -6,5 +6,9 @@ require("nvim-tree").setup({
     indent_markers = {
       enable = true,
     },
+    highlight_git = true,
   },
+  diagnostics = {
+    enable = true,
+  }
 })

--- a/lua/plugins/configs/tools/tree.lua
+++ b/lua/plugins/configs/tools/tree.lua
@@ -7,13 +7,4 @@ require("nvim-tree").setup({
       enable = true,
     },
   },
-  icons = {
-    git_placement = "signcolumn",
-    show = {
-      file = true,
-      folder = true,
-      folder_arrow = true,
-      git = true
-    }
-  }
 })

--- a/lua/plugins/configs/ui/catppuccin.lua
+++ b/lua/plugins/configs/ui/catppuccin.lua
@@ -38,6 +38,14 @@ require("catppuccin").setup({
       crust = "#161320",
     },
   },
+  intergrations = {
+    mason = false,
+    -- cmp = true,
+    mini = true,
+    -- telescope = true,
+    -- gitsigns = true,
+    treesitter = true,
+  },
   highlight_overrides = {
     mocha = function(cp)
       return {

--- a/lua/plugins/spec.lua
+++ b/lua/plugins/spec.lua
@@ -84,7 +84,11 @@ return {
       require("plugins.configs.lsp.lspconfig")
     end,
     dependencies = {
-      "williamboman/mason.nvim",
+      {
+        "williamboman/mason.nvim",
+        config = true,
+        cmd = "Mason",
+      },
       "williamboman/mason-lspconfig.nvim",
       "hrsh7th/nvim-cmp",
       "hrsh7th/cmp-nvim-lsp",
@@ -155,6 +159,20 @@ return {
       { "<leader>ff", "<cmd>Telescope find_files<CR>" }
     }
   },
+  {
+    "nvim-tree/nvim-tree.lua",
+    dependencies = {
+      "nvim-tree/nvim-web-devicons"
+    },
+    config = function ()
+      require("plugins.configs.tools.tree")
+    end,
+    event = "VeryLazy"
+  },
+  -- {
+  --   "ms-jpq/chadtree",
+  --   event = "VeryLazy",
+  -- },
   -- Treesitter
   {
     "nvim-treesitter/nvim-treesitter",


### PR DESCRIPTION
#55 
Add `nvim-tree/nvim-tree.lua`. Why add a tree explorer even though we have Telescope.nvim? Because sometimes trees may be more useful in some cases. Ex. Easily searching outside the folder we're editing etc..