### PR TITLE
fix(dial, treesj): Make them toggable-able within the options

### DIFF
--- a/lua/plugins/specs/coding.lua
+++ b/lua/plugins/specs/coding.lua
@@ -194,6 +194,7 @@ return not dots.coding.enabled and {}
           callback = create_keymaps,
         })
       end,
+      enabled = dots.coding.dial.enabled,
       event = "VeryLazy",
     },
     {

--- a/lua/settings/init.lua
+++ b/lua/settings/init.lua
@@ -235,6 +235,9 @@ M.coding = {
       "svelte",
     },
   },
+  dial = {
+    enabled = true,
+  },
 }
 
 M.editor = {
@@ -258,9 +261,6 @@ M.editor = {
     enabled = true,
   },
   treesitter = {
-    enabled = true,
-  },
-  dial = {
     enabled = true,
   },
 }


### PR DESCRIPTION
I've made both dial.nvim and treesj toggable-able within the options (`lua/settings/init.lua`)