### PR TITLE
feat(catppuccin): Use the default highlight for variables

### DIFF
--- a/lua/plugins/specs/ui.lua
+++ b/lua/plugins/specs/ui.lua
@@ -4,7 +4,6 @@ return {
     opts = {
       custom_highlights = function(C)
         return {
-          ["@variable"] = { fg = C.flamingo },
           Pmenu = { bg = C.mantle },
           PmenuSel = { bg = C.blue, fg = C.base, style = { "bold" } },
         }


### PR DESCRIPTION
It's white.
It's colored white.
I don't like it.
Thus I've reverted to it.